### PR TITLE
Add UI and mutation support for updating applicant stage

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9,6 +9,7 @@ type Mutation {
   updateJob(id: ID!, input: JobInput!): AdminJob!
   updateJobStatus(id: ID!, status: JobStatus!): AdminJob!
   submitApplicationText(input: ApplicantTextInput!, cv: Upload!, coverLetter: Upload!): Applicant!
+  updateApplicantStage(id: String!, stage: Stage!): Applicant!
 }
 
 """

--- a/src/__generated__/applicantMutations_UpdateApplicantStageMutation.graphql.ts
+++ b/src/__generated__/applicantMutations_UpdateApplicantStageMutation.graphql.ts
@@ -1,0 +1,109 @@
+/**
+ * @generated SignedSource<<fcf990eb6f0d99ac545fd4d72d3e880c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type Stage = "APPLIED" | "HIRED" | "INTERVIEWED" | "REJECTED" | "SHORTLISTED" | "%future added value";
+export type applicantMutations_UpdateApplicantStageMutation$variables = {
+  id: string;
+  stage: Stage;
+};
+export type applicantMutations_UpdateApplicantStageMutation$data = {
+  readonly updateApplicantStage: {
+    readonly id: string;
+    readonly stage: Stage;
+  };
+};
+export type applicantMutations_UpdateApplicantStageMutation = {
+  response: applicantMutations_UpdateApplicantStageMutation$data;
+  variables: applicantMutations_UpdateApplicantStageMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "stage"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "id",
+        "variableName": "id"
+      },
+      {
+        "kind": "Variable",
+        "name": "stage",
+        "variableName": "stage"
+      }
+    ],
+    "concreteType": "Applicant",
+    "kind": "LinkedField",
+    "name": "updateApplicantStage",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "id",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "stage",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "applicantMutations_UpdateApplicantStageMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "applicantMutations_UpdateApplicantStageMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d75733a18002516f3bc32517fbddacb6",
+    "id": null,
+    "metadata": {},
+    "name": "applicantMutations_UpdateApplicantStageMutation",
+    "operationKind": "mutation",
+    "text": "mutation applicantMutations_UpdateApplicantStageMutation(\n  $id: String!\n  $stage: Stage!\n) {\n  updateApplicantStage(id: $id, stage: $stage) {\n    id\n    stage\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "56a896917d5833bdf1e9743825221814";
+
+export default node;

--- a/src/app/(admin)/applicant/ApplicantStageAction.tsx
+++ b/src/app/(admin)/applicant/ApplicantStageAction.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useToast } from '@/context/ToastContext';
+import StatusDropdown from '@/components/StatusDropdown';
+import { useUpdateApplicantStage } from '@/modules/applicants/hooks/useUpdateApplicantStage';
+
+type Props = {
+    id: string;
+    currentStage: 'APPLIED' | 'SHORTLISTED' | 'INTERVIEWED' | 'HIRED' | 'REJECTED';
+};
+
+const stageOptions = ['APPLIED', 'SHORTLISTED', 'INTERVIEWED', 'HIRED', 'REJECTED'];
+
+const ApplicantStageAction = ({ id, currentStage }: Props) => {
+    const [commit, isInFlight] = useUpdateApplicantStage();
+    const { addToast } = useToast();
+
+    const handleChange = (newStage: Props['currentStage']) => {
+        if (newStage === currentStage) return;
+
+        commit({
+            variables: { id, stage: newStage },
+            onCompleted: () => addToast(`Stage updated to ${newStage}`, 'success'),
+            onError: (err) => {
+                console.error(err);
+                addToast('Failed to update stage.', 'error');
+            }
+        });
+    };
+
+    return (
+        <StatusDropdown
+            options={stageOptions}
+            currentValue={currentStage}
+            onChange={handleChange}
+            loading={isInFlight}
+        />
+    );
+};
+
+export default ApplicantStageAction;

--- a/src/modules/applicants/graphql/applicantMutations.ts
+++ b/src/modules/applicants/graphql/applicantMutations.ts
@@ -1,0 +1,10 @@
+import { graphql } from 'react-relay';
+
+export const UpdateApplicantStageMutation = graphql`
+  mutation applicantMutations_UpdateApplicantStageMutation($id: String!, $stage: Stage!) {
+    updateApplicantStage(id: $id, stage: $stage) {
+      id
+      stage
+    }
+  }
+`;

--- a/src/modules/applicants/hooks/useUpdateApplicantStage.ts
+++ b/src/modules/applicants/hooks/useUpdateApplicantStage.ts
@@ -1,0 +1,7 @@
+import { useMutation } from 'react-relay';
+import { UpdateApplicantStageMutation } from '../graphql/applicantMutations';
+import { applicantMutations_UpdateApplicantStageMutation as MutationType } from '@/__generated__/applicantMutations_UpdateApplicantStageMutation.graphql';
+
+export const useUpdateApplicantStage = () => {
+    return useMutation<MutationType>(UpdateApplicantStageMutation);
+};

--- a/src/utils/applicantColumns.tsx
+++ b/src/utils/applicantColumns.tsx
@@ -1,6 +1,7 @@
 import { Column } from '@/components/DataTable';
 import { FaArchive, FaEdit } from 'react-icons/fa';
 import Link from 'next/link';
+import ApplicantStageAction from '@/app/(admin)/applicant/ApplicantStageAction';
 
 export type Applicant = {
     id: string;
@@ -34,11 +35,7 @@ export const applicantColumns: Column<Applicant>[] = [
         label: 'Actions',
         render: (_val, row) => (
             <div className="flex gap-2">
-                <button
-                    className="flex items-center gap-1 px-4 py-2 rounded-full text-red-600 border border-red-600 hover:bg-red-100 transition duration-150"
-                >
-                    <FaArchive className="text-sm" />
-                </button>
+                <ApplicantStageAction id={row.id} currentStage={row.stage} />
             </div>
         ),
     }


### PR DESCRIPTION
**Summary**

This PR adds interactive functionality to update an applicant's stage directly from the admin dashboard table using the existing `StatusDropdown` component.

**Features**

- Integrated `StatusDropdown` for applicant stage updates
- Added new component: `ApplicantStageAction`:
  - Accepts applicant `id` and current `stage`
  - Triggers a Relay mutation to update the stage
- Uses the `useUpdateApplicantStage` custom hook to commit the mutation
- Displays toast notifications on success/failure
- Keeps dropdown disabled during network activity for better UX
