### PR TITLE
Fetch and render dynamic KPI metrics and monthly trends in admin dashboard

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -81,6 +81,8 @@ type Query {
   getJobById(id: String!): Job!
   applicants(search: String, stage: Stage, skip: Int, take: Int): ApplicantsResponse!
   getApplicantById(id: String!): Applicant!
+  dashboardStats: DashboardStats!
+  monthlyTrends: [MonthlyStats!]!
 }
 
 """The `Upload` scalar type represents a file upload."""
@@ -135,4 +137,18 @@ input ApplicantTextInput {
   phone: String!
   jobId: String!
   message: String
+}
+
+type DashboardStats {
+  activeJobs: Int!
+  totalApplicants: Int!
+  topJob: String!
+  shortlistedCount: Int!
+}
+
+type MonthlyStats {
+  month: String!
+  jobs: Int!
+  applicants: Int!
+  hired: Int!
 }

--- a/src/__generated__/analyticsQueries_DashboardStatsQuery.graphql.ts
+++ b/src/__generated__/analyticsQueries_DashboardStatsQuery.graphql.ts
@@ -1,0 +1,98 @@
+/**
+ * @generated SignedSource<<498f76989ae9326e9fd750112440c54a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type analyticsQueries_DashboardStatsQuery$variables = Record<PropertyKey, never>;
+export type analyticsQueries_DashboardStatsQuery$data = {
+  readonly dashboardStats: {
+    readonly activeJobs: number;
+    readonly shortlistedCount: number;
+    readonly topJob: string;
+    readonly totalApplicants: number;
+  };
+};
+export type analyticsQueries_DashboardStatsQuery = {
+  response: analyticsQueries_DashboardStatsQuery$data;
+  variables: analyticsQueries_DashboardStatsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "DashboardStats",
+    "kind": "LinkedField",
+    "name": "dashboardStats",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "activeJobs",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "totalApplicants",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "topJob",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "shortlistedCount",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "analyticsQueries_DashboardStatsQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "analyticsQueries_DashboardStatsQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "097ebdd0fab72c83f980df68940186e7",
+    "id": null,
+    "metadata": {},
+    "name": "analyticsQueries_DashboardStatsQuery",
+    "operationKind": "query",
+    "text": "query analyticsQueries_DashboardStatsQuery {\n  dashboardStats {\n    activeJobs\n    totalApplicants\n    topJob\n    shortlistedCount\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ad56b79bcb2e4a4b83f187d1c32608c6";
+
+export default node;

--- a/src/__generated__/analyticsQueries_MonthlyTrendsQuery.graphql.ts
+++ b/src/__generated__/analyticsQueries_MonthlyTrendsQuery.graphql.ts
@@ -1,0 +1,98 @@
+/**
+ * @generated SignedSource<<f5751943756e4fb597d1bcd547e9b903>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type analyticsQueries_MonthlyTrendsQuery$variables = Record<PropertyKey, never>;
+export type analyticsQueries_MonthlyTrendsQuery$data = {
+  readonly monthlyTrends: ReadonlyArray<{
+    readonly applicants: number;
+    readonly hired: number;
+    readonly jobs: number;
+    readonly month: string;
+  }>;
+};
+export type analyticsQueries_MonthlyTrendsQuery = {
+  response: analyticsQueries_MonthlyTrendsQuery$data;
+  variables: analyticsQueries_MonthlyTrendsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "MonthlyStats",
+    "kind": "LinkedField",
+    "name": "monthlyTrends",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "month",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "jobs",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "applicants",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "hired",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "analyticsQueries_MonthlyTrendsQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "analyticsQueries_MonthlyTrendsQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "75f2adabe2cadb7cfb2c4a0adfcfb091",
+    "id": null,
+    "metadata": {},
+    "name": "analyticsQueries_MonthlyTrendsQuery",
+    "operationKind": "query",
+    "text": "query analyticsQueries_MonthlyTrendsQuery {\n  monthlyTrends {\n    month\n    jobs\n    applicants\n    hired\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f798a00c8ef31c55e5256fafbb8f9424";
+
+export default node;

--- a/src/components/admin/dashboard/JobTrendChart.tsx
+++ b/src/components/admin/dashboard/JobTrendChart.tsx
@@ -1,19 +1,9 @@
-'use client';
-
-import {
-    LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
-} from 'recharts';
-
-const data = [
-    { month: 'Jan', jobs: 4 },
-    { month: 'Feb', jobs: 7 },
-    { month: 'Mar', jobs: 5 },
-    { month: 'Apr', jobs: 9 },
-    { month: 'May', jobs: 12 },
-    { month: 'Jun', jobs: 8 },
-];
+import { useMonthlyTrends } from '@/modules/dashboard/hooks/useMonthlyTrends';
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 export default function JobTrendChart() {
+    const data = useMonthlyTrends();
+
     return (
         <div className="bg-white shadow-md rounded-lg p-6">
             <h2 className="text-lg font-semibold mb-4 text-[#012C56]">Monthly Job Postings</h2>
@@ -24,6 +14,8 @@ export default function JobTrendChart() {
                     <YAxis />
                     <Tooltip />
                     <Line type="monotone" dataKey="jobs" stroke="#012C56" strokeWidth={2} />
+                    <Line type="monotone" dataKey="applicants" stroke="#2e4257" strokeWidth={2} />
+                    <Line type="monotone" dataKey="hired" stroke="#00a86b" strokeWidth={2} />
                 </LineChart>
             </ResponsiveContainer>
         </div>

--- a/src/components/admin/dashboard/StatCardsGrid.tsx
+++ b/src/components/admin/dashboard/StatCardsGrid.tsx
@@ -1,20 +1,17 @@
+import { useDashboardStats } from '@/modules/dashboard/hooks/useDashboardStats';
 import StatCard from './StatCard';
 import { STAT_CARD_META } from '@/utils/admin/statCardsMeta';
 
-const values = {
-    activeJobs: 12,
-    totalApplicants: 320,
-    topJob: '84 Applications',
-};
-
 export default function StatCardsGrid() {
+    const stats = useDashboardStats();
+
     return (
         <div className="grid gap-6 auto-rows-fr grid-cols-[repeat(auto-fit,minmax(250px,1fr))]">
             {STAT_CARD_META.map(({ key, label, icon: Icon, bgColor, textColor }) => (
                 <StatCard
                     key={key}
                     label={label}
-                    value={values[key as keyof typeof values]}
+                    value={stats[key as keyof typeof stats]}
                     icon={<Icon className="w-8 h-8" />}
                     bgColor={bgColor}
                     textColor={textColor}

--- a/src/modules/dashboard/graphql/analyticsQueries.ts
+++ b/src/modules/dashboard/graphql/analyticsQueries.ts
@@ -1,0 +1,23 @@
+import { graphql } from 'react-relay';
+
+export const DashboardStatsQuery = graphql`
+  query analyticsQueries_DashboardStatsQuery {
+    dashboardStats {
+      activeJobs
+      totalApplicants
+      topJob
+      shortlistedCount
+    }
+  }
+`;
+
+export const MonthlyTrendsQuery = graphql`
+  query analyticsQueries_MonthlyTrendsQuery {
+    monthlyTrends {
+      month
+      jobs
+      applicants
+      hired
+    }
+  }
+`;

--- a/src/modules/dashboard/hooks/useDashboardStats.ts
+++ b/src/modules/dashboard/hooks/useDashboardStats.ts
@@ -1,0 +1,12 @@
+import { useLazyLoadQuery } from 'react-relay';
+import { DashboardStatsQuery } from '../graphql/analyticsQueries';
+import { analyticsQueries_DashboardStatsQuery } from '@/__generated__/analyticsQueries_DashboardStatsQuery.graphql';
+
+export const useDashboardStats = () => {
+    const data = useLazyLoadQuery<analyticsQueries_DashboardStatsQuery>(
+        DashboardStatsQuery,
+        {},
+        { fetchPolicy: 'store-and-network' }
+    );
+    return data.dashboardStats;
+};

--- a/src/modules/dashboard/hooks/useMonthlyTrends.ts
+++ b/src/modules/dashboard/hooks/useMonthlyTrends.ts
@@ -1,0 +1,12 @@
+import { useLazyLoadQuery } from 'react-relay';
+import { MonthlyTrendsQuery } from '../graphql/analyticsQueries';
+import { analyticsQueries_MonthlyTrendsQuery } from '@/__generated__/analyticsQueries_MonthlyTrendsQuery.graphql';
+
+export const useMonthlyTrends = () => {
+    const data = useLazyLoadQuery<analyticsQueries_MonthlyTrendsQuery>(
+        MonthlyTrendsQuery,
+        {},
+        { fetchPolicy: 'store-and-network' }
+    );
+    return data.monthlyTrends;
+};

--- a/src/utils/admin/statCardsMeta.ts
+++ b/src/utils/admin/statCardsMeta.ts
@@ -31,4 +31,11 @@ export const STAT_CARD_META: StatCardMeta[] = [
         bgColor: 'bg-[#FFECE7]',
         textColor: 'text-[#C75B39]',
     },
+    {
+        key: 'shortlistedCount',
+        label: 'Shortlisted Count',
+        icon: Users,
+        bgColor: 'bg-[#F6F4FF]',
+        textColor: 'text-[#4B3D8F]',
+    },
 ];


### PR DESCRIPTION
**Summary**

This PR integrates real-time analytics into the admin dashboard by replacing static placeholders with live data fetched from the GraphQL backend using Relay.

**Changes**

- ➕ Added Relay queries and custom hooks:
  - `useDashboardStats` → for `StatCardsGrid`
  - `useMonthlyTrends` → for `JobTrendChart`

- 🧠 Dashboard metrics now include:
  - Active jobs
  - Total applicants
  - Most applied job
  - Shortlisted applicant count

- 📈 Line chart displays:
  - Jobs posted
  - Applicants received
  - Hires made (monthly breakdown)

### UI/UX

- Dynamic rendering with `store-and-network` policy for freshness
- Replaced hardcoded dashboard stat card values
- Multi-line chart for trend visualization (with distinct colors per metric)
